### PR TITLE
Add a --windowless flag to TeideTest

### DIFF
--- a/tests/TeideTest/CMakeLists.txt
+++ b/tests/TeideTest/CMakeLists.txt
@@ -4,7 +4,7 @@ if(TEIDE_TEST_VERBOSE)
     list(APPEND extra_args --verbose)
 endif()
 if(TEIDE_TEST_WINDOWLESS)
-    list(APPEND extra_args --gtest_filter=-SurfaceTest.*)
+    list(APPEND extra_args --windowless)
 endif()
 
 if(TEIDE_UNIT_TEST_SW_RENDER)

--- a/tests/TeideTest/src/Main.cpp
+++ b/tests/TeideTest/src/Main.cpp
@@ -47,7 +47,12 @@ int main(int argc, char** argv)
         else if (arg == "-v" || arg == "--verbose")
         {
             spdlog::set_level(spdlog::level::debug);
-            spdlog::debug("Verbose logging enabled");
+            spdlog::info("Verbose logging enabled");
+        }
+        else if (arg == "--windowless")
+        {
+            g_windowless = true;
+            spdlog::info("Windowless environment indicated: skipping surface tests");
         }
     }
 

--- a/tests/TeideTest/src/Teide/SurfaceTest.cpp
+++ b/tests/TeideTest/src/Teide/SurfaceTest.cpp
@@ -20,7 +20,19 @@ struct SDLWindowDeleter
 
 using UniqueSDLWindow = std::unique_ptr<SDL_Window, SDLWindowDeleter>;
 
-TEST(SurfaceTest, CreateSurface)
+class SurfaceTest : public Test
+{
+public:
+    void SetUp() override
+    {
+        if (g_windowless)
+        {
+            GTEST_SKIP();
+        }
+    }
+};
+
+TEST_F(SurfaceTest, CreateSurface)
 {
     const auto window = UniqueSDLWindow(SDL_CreateWindow("Test", 0, 0, 800, 600, SDL_WINDOW_VULKAN | SDL_WINDOW_HIDDEN));
     ASSERT_THAT(window, NotNull()) << SDL_GetError();
@@ -29,7 +41,7 @@ TEST(SurfaceTest, CreateSurface)
     EXPECT_THAT(surface->GetExtent(), Eq(Geo::Size2i{800, 600}));
 }
 
-TEST(SurfaceTest, CreateSurfaceMultisampled)
+TEST_F(SurfaceTest, CreateSurfaceMultisampled)
 {
     auto window = UniqueSDLWindow(SDL_CreateWindow("Test", 0, 0, 800, 600, SDL_WINDOW_VULKAN | SDL_WINDOW_HIDDEN));
     ASSERT_THAT(window, NotNull()) << SDL_GetError();
@@ -38,7 +50,7 @@ TEST(SurfaceTest, CreateSurfaceMultisampled)
     EXPECT_THAT(surface->GetExtent(), Eq(Geo::Size2i{800, 600}));
 }
 
-TEST(SurfaceTest, CreatePipelineForSurface)
+TEST_F(SurfaceTest, CreatePipelineForSurface)
 {
     const auto window = UniqueSDLWindow(SDL_CreateWindow("Test", 0, 0, 800, 600, SDL_WINDOW_VULKAN | SDL_WINDOW_HIDDEN));
     ASSERT_THAT(window, NotNull()) << SDL_GetError();
@@ -64,7 +76,7 @@ TEST(SurfaceTest, CreatePipelineForSurface)
     EXPECT_THAT(pipeline.get(), NotNull());
 }
 
-TEST(SurfaceTest, RenderToSurface)
+TEST_F(SurfaceTest, RenderToSurface)
 {
     auto window = UniqueSDLWindow(SDL_CreateWindow("Test", 0, 0, 800, 600, SDL_WINDOW_VULKAN | SDL_WINDOW_HIDDEN));
     ASSERT_THAT(window, NotNull()) << SDL_GetError();
@@ -80,7 +92,7 @@ TEST(SurfaceTest, RenderToSurface)
     renderer->EndFrame();
 }
 
-TEST(SurfaceTest, RenderToSurfaceWithoutClear)
+TEST_F(SurfaceTest, RenderToSurfaceWithoutClear)
 {
     auto window = UniqueSDLWindow(SDL_CreateWindow("Test", 0, 0, 800, 600, SDL_WINDOW_VULKAN | SDL_WINDOW_HIDDEN));
     ASSERT_THAT(window, NotNull()) << SDL_GetError();
@@ -94,7 +106,7 @@ TEST(SurfaceTest, RenderToSurfaceWithoutClear)
     renderer->EndFrame();
 }
 
-TEST(SurfaceTest, RenderToSurfaceTwice)
+TEST_F(SurfaceTest, RenderToSurfaceTwice)
 {
     auto window = UniqueSDLWindow(SDL_CreateWindow("Test", 0, 0, 800, 600, SDL_WINDOW_VULKAN | SDL_WINDOW_HIDDEN));
     ASSERT_THAT(window, NotNull()) << SDL_GetError();

--- a/tests/TeideTest/src/Teide/TestUtils.h
+++ b/tests/TeideTest/src/Teide/TestUtils.h
@@ -14,6 +14,8 @@
 #include <string_view>
 #include <vector>
 
+inline bool g_windowless = false;
+
 Teide::GraphicsDevicePtr CreateTestGraphicsDevice();
 
 std::optional<std::uint32_t> GetTransferQueueIndex(vk::PhysicalDevice physicalDevice);


### PR DESCRIPTION
This allows disabling surface tests while allowing use of the GTEST_FILTER env variable to run a subset of tests.
