### PR TITLE
Optimise CI build-and-test workflow

### DIFF
--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
-        submodules: recursive
+        submodules: false
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
@@ -144,7 +144,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
-        submodules: recursive
+        submodules: false
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
-        submodules: false
+        submodules: recursive
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
@@ -144,7 +144,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         lfs: true
-        submodules: false
+        submodules: recursive
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
       with:
-        extra-packages: ${{matrix.coverage == "ON" && "OpenCppCoverage"}}
+        extra-packages: ${{matrix.coverage == 'ON' && 'OpenCppCoverage'}}
 
     - name: Configure CMake
       run: cmake --preset ${{matrix.preset}} -DTEIDE_TEST_VERBOSE=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} --trace --trace-format=json-v1 --trace-redirect=CMakeTrace.txt

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
       with:
-        extra-packages: ${{matrix.coverage == 'ON' && 'OpenCppCoverage'}}
+        extra-packages: ${{matrix.coverage == 'ON' && 'OpenCppCoverage' || ''}}
 
     - name: Configure CMake
       run: cmake --preset ${{matrix.preset}} -DTEIDE_TEST_VERBOSE=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} --trace --trace-format=json-v1 --trace-redirect=CMakeTrace.txt

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
       with:
-        extra-packages: OpenCppCoverage
+        extra-packages: ${{matrix.coverage == "ON" && "OpenCppCoverage"}}
 
     - name: Configure CMake
       run: cmake --preset ${{matrix.preset}} -DTEIDE_TEST_VERBOSE=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} --trace --trace-format=json-v1 --trace-redirect=CMakeTrace.txt

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,7 +21,7 @@
       "inherits": "_common",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/Zi /W4 /WX /EHsc /permissive- /w14242 /w14254 /w14263 /w14265 /w14287 /w14289 /w14296 /w14311 /w14545 /w14546 /w14547 /w14549 /w14555 /w14619 /w14640 /w14826 /w14905 /w14906 /w14928 /w44365 /wd4324 /external:W0 /analyze:external- /external:anglebrackets",
+        "CMAKE_CXX_FLAGS": "/Zi /W4 /WX /MP /EHsc /permissive- /w14242 /w14254 /w14263 /w14265 /w14287 /w14289 /w14296 /w14311 /w14545 /w14546 /w14547 /w14549 /w14555 /w14619 /w14640 /w14826 /w14905 /w14906 /w14928 /w44365 /wd4324 /external:W0 /analyze:external- /external:anglebrackets",
         "CMAKE_CXX_FLAGS_DEBUG": "/Od /Ob0 /JMC",
         "CMAKE_EXE_LINKER_FLAGS": "/DEBUG",
         "CMAKE_CONFIGURATION_TYPES": "Debug;Release"


### PR DESCRIPTION
- Enable multithreaded builds with MSVC
- Only install OpenCppCoverage when needed