### PR TITLE
Fix conflicts when running clang-tidy

### DIFF
--- a/tools/cmake/ClangTidy.cmake
+++ b/tools/cmake/ClangTidy.cmake
@@ -8,7 +8,7 @@ function(td_add_clang_tidy)
         list(APPEND compiler_args "-D${def}")
     endforeach()
 
-    set(clang_tidy_args "--fix-notes" "--fix-errors" "--export-fixes=${CMAKE_BINARY_DIR}/clang-tidy-fixes.yaml")
+    set(clang_tidy_args "--fix" "--export-fixes=${CMAKE_BINARY_DIR}/clang-tidy-fixes.yaml")
 
     add_custom_target(
         ClangTidy


### PR DESCRIPTION
Replace `--fix-notes --fix-errors` with `--fix` on the clang-tidy commanf-line as it was causing conflicts when trying to apply fixes.