### PR TITLE
Bump clang-tidy to version 17

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: >-
   portability-*,
   misc-*,
   -misc-non-private-member-variables-in-classes,
+  -misc-include-cleaner,
   concurrency-*,
   readability-*,
   -readability-magic-numbers,

--- a/.github/workflows/Static-Analysis.yml
+++ b/.github/workflows/Static-Analysis.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  clang_tidy_version: 16
+  clang_tidy_version: 17
   pattern: '\.\(c\|cpp\|cc\|cxx\|h\|hpp\)$'
 
 jobs:

--- a/include/Teide/BasicTypes.h
+++ b/include/Teide/BasicTypes.h
@@ -4,10 +4,7 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace Teide
-{
-
-inline namespace BasicTypes
+namespace Teide::inline BasicTypes
 {
     using int8 = std::int8_t;
     using int16 = std::int16_t;
@@ -21,6 +18,4 @@ inline namespace BasicTypes
     using usize = std::size_t;
 
     using byte = std::byte;
-} // namespace BasicTypes
-
-} // namespace Teide
+    } // namespace Teide::inline BasicTypes

--- a/include/Teide/BasicTypes.h
+++ b/include/Teide/BasicTypes.h
@@ -6,16 +6,16 @@
 
 namespace Teide::inline BasicTypes
 {
-    using int8 = std::int8_t;
-    using int16 = std::int16_t;
-    using int32 = std::int32_t;
-    using int64 = std::int64_t;
-    using uint8 = std::uint8_t;
-    using uint16 = std::uint16_t;
-    using uint32 = std::uint32_t;
-    using uint64 = std::uint64_t;
+using int8 = std::int8_t;
+using int16 = std::int16_t;
+using int32 = std::int32_t;
+using int64 = std::int64_t;
+using uint8 = std::uint8_t;
+using uint16 = std::uint16_t;
+using uint32 = std::uint32_t;
+using uint64 = std::uint64_t;
 
-    using usize = std::size_t;
+using usize = std::size_t;
 
-    using byte = std::byte;
-    } // namespace Teide::inline BasicTypes
+using byte = std::byte;
+} // namespace Teide::inline BasicTypes

--- a/include/Teide/Definitions.h
+++ b/include/Teide/Definitions.h
@@ -15,7 +15,7 @@ constexpr bool IsDebugBuild = true;
 
 [[noreturn]] inline void Unreachable()
 {
-    std::cerr << UnreachableMessage << std::endl;
+    std::cerr << UnreachableMessage << '\n';
     std::exit(1); // NOLINT(concurrency-mt-unsafe)
 }
 

--- a/src/Teide/VulkanGraphicsDevice.cpp
+++ b/src/Teide/VulkanGraphicsDevice.cpp
@@ -725,7 +725,7 @@ RendererPtr VulkanGraphicsDevice::CreateRenderer(ShaderEnvironmentPtr shaderEnvi
 BufferPtr VulkanGraphicsDevice::CreateBuffer(const BufferData& data, const char* name)
 {
     spdlog::debug("Creating buffer '{}' of size {}", name, data.data.size());
-    auto task = m_scheduler.ScheduleGpu([=, this](CommandBuffer& cmdBuffer) { //
+    auto task = m_scheduler.ScheduleGpu([data, name, this](CommandBuffer& cmdBuffer) { //
         return CreateBuffer(data, name, cmdBuffer);
     });
     return task.get();
@@ -798,7 +798,7 @@ ShaderPtr VulkanGraphicsDevice::CreateShader(const ShaderData& data, const char*
 TexturePtr VulkanGraphicsDevice::CreateTexture(const TextureData& data, const char* name)
 {
     spdlog::debug("Creating texture '{}' of size {}x{}", name, data.size.x, data.size.y);
-    auto task = m_scheduler.ScheduleGpu([=, this](CommandBuffer& cmdBuffer) { //
+    auto task = m_scheduler.ScheduleGpu([data, name, this](CommandBuffer& cmdBuffer) { //
         return CreateTexture(data, name, cmdBuffer);
     });
     return task.get();
@@ -827,7 +827,7 @@ TexturePtr VulkanGraphicsDevice::CreateTexture(const TextureData& data, const ch
 TexturePtr VulkanGraphicsDevice::CreateRenderableTexture(const TextureData& data, const char* name)
 {
     spdlog::debug("Creating renderable texture '{}' of size {}x{}", name, data.size.x, data.size.y);
-    auto task = m_scheduler.ScheduleGpu([=, this](CommandBuffer& cmdBuffer) { //
+    auto task = m_scheduler.ScheduleGpu([data, name, this](CommandBuffer& cmdBuffer) { //
         return CreateRenderableTexture(data, name, cmdBuffer);
     });
     return task.get();
@@ -1083,7 +1083,7 @@ Framebuffer VulkanGraphicsDevice::CreateFramebuffer(
 ParameterBlockPtr VulkanGraphicsDevice::CreateParameterBlock(const ParameterBlockData& data, const char* name)
 {
     spdlog::debug("Creating parameter block '{}'", name);
-    auto task = m_scheduler.ScheduleGpu([=, this](CommandBuffer& cmdBuffer) {
+    auto task = m_scheduler.ScheduleGpu([data, name, this](CommandBuffer& cmdBuffer) {
         return CreateParameterBlock(data, name, cmdBuffer, m_mainDescriptorPool.get());
     });
     return task.get();

--- a/src/Teide/VulkanRenderer.cpp
+++ b/src/Teide/VulkanRenderer.cpp
@@ -48,7 +48,7 @@ namespace
         {
             if (clearState.colorValue.has_value())
             {
-                clearValues.push_back(vk::ClearColorValue{*clearState.colorValue});
+                clearValues.emplace_back(vk::ClearColorValue{*clearState.colorValue});
             }
             else
             {


### PR DESCRIPTION
- Bump clang-tidy to version 17
- Remove misc-include-cleaner from list of checks
