### PR TITLE
Unify Windows and Linux jobs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 3
+    after_n_builds: 4
     wait_for_ci: yes
 github_checks:
   annotations: true

--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -15,18 +15,21 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        preset: [msvc2022, msvc2022-clang]
+        preset: [msvc2022, msvc2022-clang, g++-13, clang++-17]
         include:
         - preset: msvc2022
           runner: windows-2022
         - preset: msvc2022-clang
           runner: windows-2022
+        - preset: g++-13
+          runner: ubuntu-latest
+          extra-packages: ninja-build g++-13
+        - preset: clang++-17
+          runner: ubuntu-latest
+          extra-packages: ninja-build clang++-17
 
-    name: Windows-${{matrix.preset}}
+    name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.preset}}
     runs-on: ${{matrix.runner}}
-
-    env:
-      job_name: Windows-${{matrix.preset}}
 
     steps:
     - name: Checkout
@@ -39,62 +42,18 @@ jobs:
       id: cache
       uses: actions/cache@v3
       with:
-        key: vcpkg-export-${{env.job_name}}-${{hashFiles('vckpg.json','external/ports/**')}}
+        key: vcpkg-export-${{matrix.runner}}-${{matrix.preset}}-${{hashFiles('vckpg.json','external/ports/**')}}
         path: './exports'
 
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/install-dependencies
+      with:
+        extra-packages: ${{matrix.extra-packages}}
 
     - name: Configure CMake
       if: steps.cache.outputs.cache-hit != 'true'
       run: cmake --preset ${{matrix.preset}}
-
-    - name: Export packages
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        ./external/vcpkg/vcpkg export --raw --output-dir=./exports --x-install-root=build/${{matrix.preset}}/vcpkg_installed
-
-  linux:
-    strategy:
-      matrix:
-        preset: [g++-13, clang++-17]
-        include:
-        - preset: g++-13
-          runner: ubuntu-latest
-        - preset: clang++-17
-          runner: ubuntu-latest
-      fail-fast: true
-
-    name: Linux-${{matrix.preset}}
-    runs-on: ${{matrix.runner}}
-
-    env:
-      job_name: Linux-${{matrix.preset}}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        lfs: false
-        submodules: recursive
-
-    - name: Cache
-      id: cache
-      uses: actions/cache@v3
-      with:
-        key: vcpkg-export-${{env.job_name}}-${{hashFiles('vckpg.json','external/ports/**')}}
-        path: './exports'
-
-    - name: Install dependencies
-      if: steps.cache.outputs.cache-hit != 'true'
-      uses: ./.github/actions/install-dependencies
-      with:
-        extra-packages: ninja-build ${{matrix.preset}}
-
-    - name: Configure CMake
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: cmake --preset ${{matrix.preset}} -DCMAKE_CXX_COMPILER=${{matrix.preset}}
 
     - name: Export packages
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -60,10 +60,10 @@ jobs:
       matrix:
         preset: [g++-13, clang++-17]
         include:
-        - preset: msvc2022
-          runner: windows-2022
-        - preset: msvc2022-clang
-          runner: windows-2022
+        - preset: g++-13
+          runner: ubuntu-latest
+        - preset: clang++-17
+          runner: ubuntu-latest
       fail-fast: true
 
     name: Linux-${{matrix.preset}}

--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -11,7 +11,7 @@ env:
   VCPKG_OVERLAY_PORTS: ./external/ports
 
 jobs:
-  windows:
+  unified:
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -58,15 +58,19 @@ jobs:
   linux:
     strategy:
       matrix:
-        compiler: [g++-13, clang++-17]
-        preset: [ninja]
+        preset: [g++-13, clang++-17]
+        include:
+        - preset: msvc2022
+          runner: windows-2022
+        - preset: msvc2022-clang
+          runner: windows-2022
       fail-fast: true
 
-    name: Linux-${{matrix.compiler}}
-    runs-on: ubuntu-latest
+    name: Linux-${{matrix.preset}}
+    runs-on: ${{matrix.runner}}
 
     env:
-      job_name: Linux-${{matrix.compiler}}
+      job_name: Linux-${{matrix.preset}}
 
     steps:
     - name: Checkout
@@ -86,11 +90,11 @@ jobs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: ./.github/actions/install-dependencies
       with:
-        extra-packages: ninja-build ${{matrix.compiler}}
+        extra-packages: ninja-build ${{matrix.preset}}
 
     - name: Configure CMake
       if: steps.cache.outputs.cache-hit != 'true'
-      run: cmake --preset ${{matrix.preset}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}}
+      run: cmake --preset ${{matrix.preset}} -DCMAKE_CXX_COMPILER=${{matrix.preset}}
 
     - name: Export packages
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -24,25 +24,48 @@ env:
   EXTRA_CMAKE_FLAGS: ${{inputs.profile-cmake && '--profiling-format=google-trace --profiling-output=CMakeTrace.json' || ''}}
 
 jobs:
-  windows:
+  unified:
     strategy:
       fail-fast: false
       matrix:
+        preset: [msvc2022, msvc2022-clang, g++-13, clang++-17]
         buildtype: [Debug, Release]
-        preset: [msvc2022, msvc2022-clang]
+        sanitizer: [OFF]
         include:
+        # Overrides
+        - coverage: OFF
         - preset: msvc2022
           runner: windows-2022
           coverage: ${{toJSON(inputs.coverage) != 'false' && 'ON' || 'OFF'}}
         - preset: msvc2022-clang
           runner: windows-2022
-          coverage: OFF
+        - preset: g++-13
+          runner: ubuntu-latest
+          extra-packages: ninja-build g++-13
+        - preset: clang++-17
+          runner: ubuntu-latest
+          extra-packages: ninja-build clang++-17
+          coverage: ${{toJSON(inputs.coverage) != 'false' && 'ON' || 'OFF'}}
 
-    name: Windows-${{matrix.buildtype}}-${{matrix.preset}}
+        # Additional jobs
+        - preset: clang++-17
+          buildtype: Debug
+          runner: ubuntu-latest
+          extra-packages: ninja-build clang++-17
+          sanitizer: ASAN
+          name-suffix: -asan
+        - preset: clang++-17
+          buildtype: Debug
+          runner: ubuntu-latest
+          extra-packages: ninja-build clang++-17
+          sanitizer: UBSAN
+          name-suffix: -ubsan
+
+    name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}
     runs-on: ${{matrix.runner}}
 
     env:
-      job_name: Windows-${{matrix.buildtype}}-${{matrix.preset}}
+      job_name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}
       CMAKE_BUILD_TYPE: ${{matrix.buildtype}}
 
     steps:
@@ -54,8 +77,10 @@ jobs:
 
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
+      with:
+        extra-packages: ${{matrix.extra-packages}}
 
-    - if: matrix.coverage == 'ON'
+    - if: matrix.coverage == 'ON' && runner.os == 'Windows'
       name: Install OpenCppCoverage
       uses: ./.github/actions/choco-install
       with:
@@ -63,7 +88,7 @@ jobs:
         package-version: 0.9.9.0
 
     - name: Configure CMake
-      run: cmake --preset ${{matrix.preset}} -DTEIDE_PRECOMPILED_HEADERS=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} -DCMAKE_CONFIGURATION_TYPES=${{matrix.buildtype}} -DCMAKE_TRY_COMPILE_CONFIGURATION=${{matrix.buildtype}} ${{env.EXTRA_CMAKE_FLAGS}}
+      run: cmake --preset ${{matrix.preset}} -DTEIDE_PRECOMPILED_HEADERS=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_WINDOWLESS=${{runner.os == 'Linux'}} -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} -DTEIDE_SANITIZER=${{matrix.sanitizer}} -DCMAKE_CONFIGURATION_TYPES=${{matrix.buildtype}} -DCMAKE_TRY_COMPILE_CONFIGURATION=${{matrix.buildtype}} ${{env.EXTRA_CMAKE_FLAGS}}
 
     - name: Save CMake trace
       if: inputs.profile-cmake
@@ -118,115 +143,10 @@ jobs:
         name: CoverageReport-${{env.job_name}}
         path: build/${{matrix.preset}}/coverage/output
 
-  linux:
-    strategy:
-      matrix:
-        buildtype: [Debug, Release]
-        preset: [g++-13, clang++-17]
-        sanitizer: [OFF]
-        include:
-        # Overrides
-        - coverage: OFF
-        - preset: g++-13
-          extra-packages: ninja-build g++-13
-        - preset: clang++-17
-          extra-packages: ninja-build clang++-17
-        - buildtype: Debug
-          preset: clang++-17
-          sanitizer: OFF
-          coverage: ${{toJSON(inputs.coverage) != 'false' && 'ON' || 'OFF'}}
-
-        # Additional jobs
-        - buildtype: Debug
-          preset: clang++-17
-          extra-packages: ninja-build clang++-17
-          sanitizer: ASAN
-          name-suffix: -asan
-        - buildtype: Debug
-          preset: clang++-17
-          extra-packages: ninja-build clang++-17
-          sanitizer: UBSAN
-          name-suffix: -ubsan
-      fail-fast: false
-
-    name: Linux-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
-    runs-on: ubuntu-latest
-
-    env:
-      job_name: Linux-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        lfs: true
-        submodules: recursive
-
-    - name: Install dependencies
-      uses: ./.github/actions/install-dependencies
-      with:
-        extra-packages: ${{matrix.extra-packages}}
-
-    - name: Configure CMake
-      run: cmake --preset ${{matrix.preset}} -DTEIDE_PRECOMPILED_HEADERS=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_WINDOWLESS=ON -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} -DTEIDE_SANITIZER=${{matrix.sanitizer}} ${{env.EXTRA_CMAKE_FLAGS}}
-
-    - name: Save CMake trace
-      if: inputs.profile-cmake
-      uses: actions/upload-artifact@v3
-      with:
-        name: CMakeTrace-${{env.job_name}}
-        path: ./CMakeTrace.json
-
-    - name: Build
-      run: cmake --build --preset ${{matrix.preset}} --config ${{matrix.buildtype}}
-
-    - name: Save CMake output logs
-      if: failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: CMakeLogs-${{env.job_name}}
-        path: |
-          ./build/${{matrix.preset}}/**/*.log
-          ./external/vcpkg/**/*.log
-
-    - name: Test
-      id: test
-      run: ctest --preset ${{matrix.preset}} --build-config ${{matrix.buildtype}} --verbose --no-tests=error
-
-    - name: Save render test output
-      if: steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v3
-      with:
-        name: RenderTestOutput-${{env.job_name}}
-        path: RenderTestOutput
-
-    - name: Save test log
-      if: steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v3
-      with:
-        name: TestLog-${{env.job_name}}
-        path: build/${{matrix.preset}}/Testing/Temporary/LastTest.log
-
-    - name: Upload coverage report
-      if: matrix.coverage == 'ON'
-      uses: codecov/codecov-action@v3
-      with:
-        directory: build/${{matrix.preset}}/coverage/output
-        fail_ci_if_error: false
-        verbose: true
-        functionalities: fixes
-
-    - name: Save coverage report
-      if: matrix.coverage == 'ON'
-      uses: actions/upload-artifact@v3
-      with:
-        name: CoverageReport-${{env.job_name}}
-        path: build/${{matrix.preset}}/coverage/output
-
   time-report:
     name: Time-Report
     runs-on: ubuntu-latest
-    needs: [windows, linux]
+    needs: [unified]
     if: ${{ github.event_name == 'push' }}
     env:
       GH_TOKEN: ${{github.token}}

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -122,33 +122,38 @@ jobs:
     strategy:
       matrix:
         buildtype: [Debug, Release]
-        compiler: [g++-13, clang++-17]
+        preset: [g++-13, clang++-17]
         sanitizer: [OFF]
         include:
-        - preset: ninja
+        # Overrides
         - coverage: OFF
+        - preset: g++-13
+          extra-packages: ninja-build g++-13
+        - preset: clang++-17
+          extra-packages: ninja-build clang++-17
         - buildtype: Debug
-          compiler: clang++-17
+          preset: clang++-17
+          sanitizer: OFF
           coverage: ${{toJSON(inputs.coverage) != 'false' && 'ON' || 'OFF'}}
+
+        # Additional jobs
         - buildtype: Debug
-          compiler: clang++-17
+          preset: clang++-17
+          extra-packages: ninja-build clang++-17
           sanitizer: ASAN
-          preset: ninja
-          coverage: OFF
           name-suffix: -asan
         - buildtype: Debug
-          compiler: clang++-17
+          preset: clang++-17
+          extra-packages: ninja-build clang++-17
           sanitizer: UBSAN
-          preset: ninja
-          coverage: OFF
           name-suffix: -ubsan
       fail-fast: false
 
-    name: Linux-${{matrix.buildtype}}-${{matrix.compiler}}${{matrix.name-suffix}}
+    name: Linux-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
     runs-on: ubuntu-latest
 
     env:
-      job_name: Linux-${{matrix.buildtype}}-${{matrix.compiler}}${{matrix.name-suffix}}
+      job_name: Linux-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
 
     steps:
     - name: Checkout
@@ -160,10 +165,10 @@ jobs:
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
       with:
-        extra-packages: ninja-build ${{matrix.compiler}}
+        extra-packages: ${{matrix.extra-packages}}
 
     - name: Configure CMake
-      run: cmake --preset ${{matrix.preset}} -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DTEIDE_PRECOMPILED_HEADERS=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_WINDOWLESS=ON -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} -DTEIDE_SANITIZER=${{matrix.sanitizer}} ${{env.EXTRA_CMAKE_FLAGS}}
+      run: cmake --preset ${{matrix.preset}} -DTEIDE_PRECOMPILED_HEADERS=ON -DTEIDE_UNIT_TEST_SW_RENDER=ON -DTEIDE_TEST_WINDOWLESS=ON -DTEIDE_TEST_COVERAGE=${{matrix.coverage}} -DTEIDE_SANITIZER=${{matrix.sanitizer}} ${{env.EXTRA_CMAKE_FLAGS}}
 
     - name: Save CMake trace
       if: inputs.profile-cmake

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -61,11 +61,11 @@ jobs:
           sanitizer: UBSAN
           name-suffix: -ubsan
 
-    name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}
+    name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
     runs-on: ${{matrix.runner}}
 
     env:
-      job_name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}
+      job_name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
       CMAKE_BUILD_TYPE: ${{matrix.buildtype}}
 
     steps:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,10 +87,6 @@
       "configurePreset": "msvc2022-clang"
     },
     {
-      "name": "mingw",
-      "configurePreset": "mingw"
-    },
-    {
       "name": "make",
       "configurePreset": "make"
     },
@@ -115,10 +111,6 @@
     {
       "name": "msvc2022-clang",
       "configurePreset": "msvc2022-clang"
-    },
-    {
-      "name": "mingw",
-      "configurePreset": "mingw"
     },
     {
       "name": "make",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -61,17 +61,19 @@
       "generator": "Ninja Multi-Config"
     },
     {
-      "name": "mingw",
-      "inherits": "_common",
-      "displayName": "MinGW",
-      "generator": "MinGW Makefiles",
+      "name": "g++-13",
+      "inherits": "ninja",
+      "displayName": "Ninja with GCC 13",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "--std=c++2a -DSDL_main=main -Wall -Werror -Wno-attributes"
-      },
-      "environment": {
-        "VCPKG_TARGET_TRIPLET": "x64-mingw-dynamic",
-        "VCPKG_DEFAULT_TRIPLET": "x64-mingw-dynamic",
-        "VCPKG_DEFAULT_HOST_TRIPLET": "x64-mingw-dynamic"
+        "CMAKE_CXX_COMPILER": "g++-13"
+      }
+    },
+    {
+      "name": "clang++-17",
+      "inherits": "ninja",
+      "displayName": "Ninja with Clang 17",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++-17"
       }
     }
   ],
@@ -95,6 +97,14 @@
     {
       "name": "ninja",
       "configurePreset": "ninja"
+    },
+    {
+      "name": "g++-13",
+      "configurePreset": "g++-13"
+    },
+    {
+      "name": "clang++-17",
+      "configurePreset": "clang++-17"
     }
   ],
   "testPresets": [
@@ -117,6 +127,14 @@
     {
       "name": "ninja",
       "configurePreset": "ninja"
+    },
+    {
+      "name": "g++-13",
+      "configurePreset": "g++-13"
+    },
+    {
+      "name": "clang++-17",
+      "configurePreset": "clang++-17"
     }
   ]
 }


### PR DESCRIPTION
* Add g++-13 and clang++-17 presets
* Use new presets in Build-Packages workflow
* Remove mingw presets
* Unify Windows and Linux jobs in Build-Packages
* Use new presets in Build-and-Test workflow
* Unify Windows and Linux jobs in Build-and-Test
