### PR TITLE
Allow updating render test references from CI

### DIFF
--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -193,8 +193,7 @@ jobs:
     if: always() && needs.unified.outputs.rendertest-failures
     env:
       GH_TOKEN: ${{github.token}}
-      INPUTS: "${{toJSON(needs)}}"
-      ANY_PASSED: "${{needs.unified.outputs.rendertest-successes && 'true' || 'false'}}"
+      ANY_PASSED: "${{needs.unified.outputs.rendertest-successes}}"
 
     steps:
     - uses: actions/download-artifact@v3
@@ -203,7 +202,8 @@ jobs:
 
     - name: Generate summary
       run: |
-        echo "Render tests failed. [Click for details](https://markridgewell.github.io/TeideStats/rendertest.html?run_id=${{github.run_id}})" >> $GITHUB_STEP_SUMMARY'
+        URL="https://markridgewell.github.io/TeideStats/rendertest.html?run_id=${{github.run_id}}"
+        echo "Render tests failed. [Click for details]($URL)" >> $GITHUB_STEP_SUMMARY
 
     - name: Display structure of downloaded files
       run: ls -R

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -159,13 +159,6 @@ jobs:
       run: |
         if [ -d "$RT_OUTPUT_DIR" ]; then
           echo "failure=true" >> "$GITHUB_OUTPUT"
-          (
-            echo "# Render tests failed:"
-            for i in $(ls $RT_OUTPUT_DIR/*.out.png); do
-              echo -n ' * '
-              basename $i .out.png
-            done
-          ) >> $GITHUB_STEP_SUMMARY
         else
           echo "success=true" >> "$GITHUB_OUTPUT"
         fi
@@ -204,11 +197,13 @@ jobs:
       ANY_PASSED: "${{needs.unified.outputs.rendertest-successes && 'true' || 'false'}}"
 
     steps:
-    - run: echo "$INPUTS"
-
     - uses: actions/download-artifact@v3
       with:
         path: artifacts
+
+    - name: Generate summary
+      run: |
+        echo "Render tests failed. [Click for details](https://markridgewell.github.io/TeideStats/rendertest.html?run_id=${{github.run_id}})" >> $GITHUB_STEP_SUMMARY'
 
     - name: Display structure of downloaded files
       run: ls -R

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -180,7 +180,7 @@ jobs:
     name: Render-Test-Report
     runs-on: ubuntu-latest
     needs: [unified]
-    if: github.event_name == 'pull_request'
+    if: always()
     env:
       GH_TOKEN: ${{github.token}}
       INPUTS: "${{toJSON(needs)}}"

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -146,7 +146,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: RenderTestOutput-${{env.job_name}}
-        path: RenderTestOutput
+        path: build/${{matrix.preset}}/tests/RenderTest/RenderTestOutput
 
     - name: Save test log
       if: failure() && steps.test.outcome == 'failure'

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -153,6 +153,7 @@ jobs:
     - name: Record render test outcome
       id: rendertest
       if: failure() && steps.test.outcome == 'failure'
+      shell: bash
       run: |
         if [ -d build/${{matrix.preset}}/tests/RenderTest/RenderTestOutput ]; then
           echo "outcome=failure" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -67,9 +67,11 @@ jobs:
     env:
       job_name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
       CMAKE_BUILD_TYPE: ${{matrix.buildtype}}
+      RT_OUTPUT_DIR: build/${{matrix.preset}}/tests/RenderTest/RenderTestOutput
 
     outputs:
-      rendertest-outcome: ${{steps.rendertest.outputs.outcome}}
+      rendertest-failures: ${{steps.rendertest.outputs.failure == 'true'}}
+      rendertest-successes: ${{steps.rendertest.outputs.success == 'true'}}
 
     steps:
     - name: Checkout
@@ -148,15 +150,24 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: RenderTestOutput-${{env.job_name}}
-        path: build/${{matrix.preset}}/tests/RenderTest/RenderTestOutput
+        path: ${{env.RT_OUTPUT_DIR}}
 
     - name: Record render test outcome
       id: rendertest
-      if: failure() && steps.test.outcome == 'failure'
+      if: always()
       shell: bash
       run: |
-        if [ -d build/${{matrix.preset}}/tests/RenderTest/RenderTestOutput ]; then
-          echo "outcome=failure" >> "$GITHUB_OUTPUT"
+        if [ -d "$RT_OUTPUT_DIR" ]; then
+          echo "failure=true" >> "$GITHUB_OUTPUT"
+          (
+            echo "# Render tests failed:"
+            for i in $(ls $RT_OUTPUT_DIR/*.out.png); do
+              echo -n ' * '
+              basename $i .out.png
+            done
+          ) >> $GITHUB_STEP_SUMMARY
+        else
+          echo "success=true" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Save test log
@@ -186,10 +197,11 @@ jobs:
     name: Render-Test-Report
     runs-on: ubuntu-latest
     needs: [unified]
-    if: always() && needs.unified.outputs.rendertest-outcome == 'failure'
+    if: always() && needs.unified.outputs.rendertest-failures
     env:
       GH_TOKEN: ${{github.token}}
       INPUTS: "${{toJSON(needs)}}"
+      ANY_PASSED: "${{needs.unified.outputs.rendertest-successes && 'true' || 'false'}}"
 
     steps:
     - run: echo "$INPUTS"

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -69,12 +69,9 @@ jobs:
       CMAKE_BUILD_TYPE: ${{matrix.buildtype}}
 
     outputs:
-      ${{matrix.runner}}: ${{steps.step1.outputs.test}}
+      rendertest-outcome: ${{steps.rendertest.outputs.outcome}}
 
     steps:
-    - id: step1
-      run: echo "test=${{env.job_name}}" >> "$GITHUB_OUTPUT"
-
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -153,6 +150,14 @@ jobs:
         name: RenderTestOutput-${{env.job_name}}
         path: build/${{matrix.preset}}/tests/RenderTest/RenderTestOutput
 
+    - name: Record render test outcome
+      id: rendertest
+      if: failure() && steps.test.outcome == 'failure'
+      run: |
+        if [ -d build/${{matrix.preset}}/tests/RenderTest/RenderTestOutput ]; then
+          echo "outcome=failure" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Save test log
       if: failure() && steps.test.outcome == 'failure'
       uses: actions/upload-artifact@v3
@@ -180,7 +185,7 @@ jobs:
     name: Render-Test-Report
     runs-on: ubuntu-latest
     needs: [unified]
-    if: always()
+    if: needs.unified.outputs.rendertest-outcome == 'failure'
     env:
       GH_TOKEN: ${{github.token}}
       INPUTS: "${{toJSON(needs)}}"

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -69,7 +69,7 @@ jobs:
       CMAKE_BUILD_TYPE: ${{matrix.buildtype}}
 
     outputs:
-      ${{runner.os}}: ${{steps.step1.outputs.test}}
+      ${{matrix.runner}}: ${{steps.step1.outputs.test}}
 
     steps:
     - id: step1

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       profile-cmake:
@@ -184,9 +183,10 @@ jobs:
     if: github.event_name == 'pull_request'
     env:
       GH_TOKEN: ${{github.token}}
+      INPUTS: "${{toJSON(needs)}}"
 
     steps:
-    - run: echo "${{toJSON(needs)}}"
+    - run: echo "$INPUTS"
 
   time-report:
     name: Time-Report

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -69,7 +69,7 @@ jobs:
       CMAKE_BUILD_TYPE: ${{matrix.buildtype}}
 
     outputs:
-      output1: ${{steps.step1.outputs.test}}
+      ${{runner.os}}: ${{steps.step1.outputs.test}}
 
     steps:
     - id: step1

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -69,7 +69,13 @@ jobs:
       job_name: ${{startsWith(matrix.runner, 'windows') && 'Windows' || 'Linux'}}-${{matrix.buildtype}}-${{matrix.preset}}${{matrix.name-suffix}}
       CMAKE_BUILD_TYPE: ${{matrix.buildtype}}
 
+    outputs:
+      output1: ${{steps.step1.outputs.test}}
+
     steps:
+    - id: step1
+      run: echo "test=${{env.job_name}}" >> "$GITHUB_OUTPUT"
+
     - name: Checkout
       uses: actions/checkout@v3
       with:
@@ -171,11 +177,22 @@ jobs:
         name: CoverageReport-${{env.job_name}}
         path: build/${{matrix.preset}}/coverage/output
 
+  render-test-report:
+    name: Render-Test-Report
+    runs-on: ubuntu-latest
+    needs: [unified]
+    if: github.event_name == 'pull_request'
+    env:
+      GH_TOKEN: ${{github.token}}
+
+    steps:
+    - run: echo "${{toJSON(needs)}}"
+
   time-report:
     name: Time-Report
     runs-on: ubuntu-latest
     needs: [unified]
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push'
     env:
       GH_TOKEN: ${{github.token}}
 

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -193,6 +193,14 @@ jobs:
     steps:
     - run: echo "$INPUTS"
 
+    - uses: actions/download-artifact@v3
+      with:
+        path: artifacts
+
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: artifacts
+
   time-report:
     name: Time-Report
     runs-on: ubuntu-latest

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -185,7 +185,7 @@ jobs:
     name: Render-Test-Report
     runs-on: ubuntu-latest
     needs: [unified]
-    if: needs.unified.outputs.rendertest-outcome == 'failure'
+    #if: needs.unified.outputs.rendertest-outcome == 'failure'
     env:
       GH_TOKEN: ${{github.token}}
       INPUTS: "${{toJSON(needs)}}"

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -186,6 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unified]
     #if: needs.unified.outputs.rendertest-outcome == 'failure'
+    if: always()
     env:
       GH_TOKEN: ${{github.token}}
       INPUTS: "${{toJSON(needs)}}"

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -185,8 +185,7 @@ jobs:
     name: Render-Test-Report
     runs-on: ubuntu-latest
     needs: [unified]
-    #if: needs.unified.outputs.rendertest-outcome == 'failure'
-    if: always()
+    if: always() && needs.unified.outputs.rendertest-outcome == 'failure'
     env:
       GH_TOKEN: ${{github.token}}
       INPUTS: "${{toJSON(needs)}}"

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -16,6 +16,11 @@ on:
         required: true
         default: true
         type: boolean
+      update-references:
+        description: 'Update render test references'
+        required: true
+        default: false
+        type: boolean
 
 env:
   VULKAN_SDK: ./VULKAN_SDK
@@ -208,6 +213,41 @@ jobs:
     - name: Display structure of downloaded files
       run: ls -R
       working-directory: artifacts
+
+    - name: Checkout
+      if: inputs.update-references
+      uses: actions/checkout@v3
+      with:
+        lfs: true
+        submodules: false
+        path: repo
+
+    - name: Update references
+      if: inputs.update-references
+      working-directory: repo
+      env:
+        REFERENCES_DIR: tests/RenderTest/references
+      run: |
+        if $ANY_PASSED; then
+          echo "Not all render tests failed, cannot update references"
+          exit 1
+        else
+          python tools/update_references.py ../artifacts $REFERENCES_DIR
+        fi
+
+        echo Staging changes...
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add $REFERENCES_DIR
+        echo
+
+        echo Status:
+        git status
+        echo
+
+        echo Pushing changes...
+        git commit -m "Update render test references"
+        git push
 
   time-report:
     name: Time-Report

--- a/tools/update_references.py
+++ b/tools/update_references.py
@@ -1,0 +1,62 @@
+import argparse
+import sys
+import hashlib
+import shutil
+from pathlib import Path
+
+def make_fileset(path: Path) -> set[str]:
+    return set(x.name for x in path.iterdir())
+
+def all_same(items: list) -> bool:
+    return all(x == items[0] for x in items)
+
+def hash_file(path: Path) -> bytes:
+    buf_size = 65536
+    hash = hashlib.md5()
+    with open(path, 'rb') as f:
+        while data := f.read(buf_size):
+            hash.update(data)
+    return hash.digest()
+
+parser = argparse.ArgumentParser()
+parser.add_argument('output_dir', type=Path)
+parser.add_argument('reference_dir', type=Path)
+opts = parser.parse_args()
+
+output_dirs = [x for x in opts.output_dir.iterdir() if x.stem.startswith('RenderTestOutput-')]
+if not output_dirs:
+    print("No render test outputs found in given directory")
+    sys.exit(1)
+
+print(f"Found {len(output_dirs)} render test output directories:")
+for child in output_dirs:
+    print(" -", child.name)
+print()
+
+filesets = [make_fileset(x) for x in output_dirs]
+if not all_same(filesets):
+    print("Render tests have differing results, cannot update references")
+    sys.exit(1)
+
+out_images = [x for x in filesets[0] if x.endswith('.out.png')]
+
+print("All directories contain the same output images:")
+for name in out_images:
+    print(" -", name)
+print()
+
+for name in out_images:
+    hashes = [hash_file(x / name) for x in output_dirs]
+    if not all_same(hashes):
+        print("Output images have differing contents, cannot update references")
+        sys.exit(1)
+
+print("All output images are identical")
+print()
+
+print("Updating references...")
+for name in out_images:
+    ref_name = name.removesuffix('.out.png') + '.png'
+    source = output_dirs[0] / name
+    dest = opts.reference_dir / ref_name
+    shutil.copy(source, dest)


### PR DESCRIPTION
* Use correct output directory for render tests
* Add job for render-test report
* Download artifacts from failed workflow runs
* Report render test failures to job summary
* Add link to summary
* Update references and commit to the repo
