### PR TITLE
Bump compiler versions and fix CI build issues

### DIFF
--- a/.github/actions/choco-install/action.yml
+++ b/.github/actions/choco-install/action.yml
@@ -39,6 +39,7 @@ runs:
         # Install package
         $pathBefore = $env:path.split(";")
         choco install --ignorepackageexitcodes ${{inputs.package-name}} --version ${{inputs.package-version}} | Tee-Object -FilePath output.txt
+        Get-Content output.txt
         $installPath = (Get-Content output.txt | Select-String "Software installed to '(.*)'").matches.groups[1]
         echo "Copying $installPath\* to ~\${{inputs.package-name}}\"
         New-Item -ItemType Directory -Path "~\${{inputs.package-name}}"

--- a/.github/actions/choco-install/action.yml
+++ b/.github/actions/choco-install/action.yml
@@ -40,7 +40,7 @@ runs:
         $pathBefore = $env:path.split(";")
         choco install --ignorepackageexitcodes ${{inputs.package-name}} --version ${{inputs.package-version}} | Tee-Object -FilePath output.txt
         Get-Content output.txt
-        $installPath = (Get-Content output.txt | Select-String "Software installed to '(.*)'").matches.groups[1]
+        $installPath = (Get-Content output.txt | Select-String "(?:Software installed|Deployed) to '(.*)'").matches.groups[1]
         echo "Copying $installPath\* to ~\${{inputs.package-name}}\"
         New-Item -ItemType Directory -Path "~\${{inputs.package-name}}"
         Copy-Item -Path "$installPath\*" -Destination "~\${{inputs.package-name}}" -Recurse

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -47,6 +47,7 @@ runs:
         # If clang packages requested, add the appropriate llvm repository
         LLVM_VERSIONS=$(echo ${{inputs.extra-packages}} | tr ' ' '\n' | sed -n 's/^clang.*-\([1-9][0-9]*\)$/\1/p' | sort | uniq)
         if [ -n "${LLVM_VERSIONS}" ]; then
+          echo "Clang requested, adding LLVM repositories..."
           wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           UBUNTU_CODENAME=`sudo cat /etc/os-release | sed -n s/UBUNTU_CODENAME=//p`
           for VERSION in ${LLVM_VERSIONS}; do
@@ -57,5 +58,6 @@ runs:
           sudo apt-get update
           sudo apt-get install -y llvm
         fi
+        echo "Installing apt packages: ${{inputs.extra-packages}}"
         sudo apt-get install -y ${{inputs.extra-packages}}
         echo "::endgroup::"

--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -24,17 +24,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: [msvc2022, clang++-17]
+        preset: [msvc2022, clang++-18]
         sanitizer: ['OFF']
         include:
         - preset: msvc2022
           runner: windows-2022
-        - preset: clang++-17
+        - preset: clang++-18
           runner: ubuntu-latest
-          extra-packages: ninja-build clang++-17
-        - preset: clang++-17
+          extra-packages: ninja-build clang++-18
+        - preset: clang++-18
           runner: ubuntu-latest
-          extra-packages: ninja-build clang++-17
+          extra-packages: ninja-build clang++-18
           sanitizer: UBSAN
           name-suffix: -ubsan
 

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -39,23 +39,23 @@ jobs:
         - preset: msvc2022-clang
           runner: windows-2022
         - preset: g++-14
-          runner: ubuntu-latest
+          runner: ubuntu-24.04
           extra-packages: ninja-build g++-14
         - preset: clang++-17
-          runner: ubuntu-latest
+          runner: ubuntu-24.04
           extra-packages: ninja-build clang++-17
           coverage: ${{toJSON(inputs.coverage) != 'false' && 'ON' || 'OFF'}}
 
         # Additional jobs
         - preset: clang++-17
           buildtype: Debug
-          runner: ubuntu-latest
+          runner: ubuntu-24.04
           extra-packages: ninja-build clang++-17
           sanitizer: ASAN
           name-suffix: -asan
         - preset: clang++-17
           buildtype: Debug
-          runner: ubuntu-latest
+          runner: ubuntu-24.04
           extra-packages: ninja-build clang++-17
           sanitizer: UBSAN
           name-suffix: -ubsan

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: [msvc2022, msvc2022-clang, g++-14, clang++-17]
+        preset: [msvc2022, msvc2022-clang, g++-14, clang++-18]
         buildtype: [Debug, Release]
         sanitizer: [OFF]
         include:
@@ -41,22 +41,22 @@ jobs:
         - preset: g++-14
           runner: ubuntu-24.04
           extra-packages: ninja-build g++-14
-        - preset: clang++-17
+        - preset: clang++-18
           runner: ubuntu-24.04
-          extra-packages: ninja-build clang++-17
+          extra-packages: ninja-build clang++-18
           coverage: ${{toJSON(inputs.coverage) != 'false' && 'ON' || 'OFF'}}
 
         # Additional jobs
-        - preset: clang++-17
+        - preset: clang++-18
           buildtype: Debug
           runner: ubuntu-24.04
-          extra-packages: ninja-build clang++-17
+          extra-packages: ninja-build clang++-18
           sanitizer: ASAN
           name-suffix: -asan
-        - preset: clang++-17
+        - preset: clang++-18
           buildtype: Debug
           runner: ubuntu-24.04
-          extra-packages: ninja-build clang++-17
+          extra-packages: ninja-build clang++-18
           sanitizer: UBSAN
           name-suffix: -ubsan
 

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -240,7 +240,7 @@ jobs:
     - name: Push workflow run data
       uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
       env:
-        API_TOKEN_GITHUB: ${{secrets.API_TOKEN_GITHUB}}
+        API_TOKEN_GITHUB: ${{secrets.API_TOKEN_TEIDESTATS}}
       with:
         source_file: '${{github.sha}}.json'
         destination_repo: '${{github.repository}}Stats'

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        preset: [msvc2022, msvc2022-clang, g++-13, clang++-17]
+        preset: [msvc2022, msvc2022-clang, g++-14, clang++-17]
         buildtype: [Debug, Release]
         sanitizer: [OFF]
         include:
@@ -38,9 +38,9 @@ jobs:
           coverage: ${{toJSON(inputs.coverage) != 'false' && 'ON' || 'OFF'}}
         - preset: msvc2022-clang
           runner: windows-2022
-        - preset: g++-13
+        - preset: g++-14
           runner: ubuntu-latest
-          extra-packages: ninja-build g++-13
+          extra-packages: ninja-build g++-14
         - preset: clang++-17
           runner: ubuntu-latest
           extra-packages: ninja-build clang++-17

--- a/.github/workflows/Run-Benchmarks.yml
+++ b/.github/workflows/Run-Benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       uses: ./.github/actions/install-dependencies
       with:
-        extra-packages: ninja-build g++-13
+        extra-packages: ninja-build g++-14
 
     - name: Install google benchmark tools
       run: |
@@ -44,7 +44,7 @@ jobs:
       run: |
         base_ref=$(git merge-base "${{github.sha}}" "origin/${{inputs.base-branch}}")
         python tools/benchmark.py compare \
-          --preset g++-13 \
+          --preset g++-14 \
           --out-dir benchmark_results \
           --out-report report.txt \
           --out-summary summary.md \

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -60,11 +60,11 @@
       "generator": "Ninja Multi-Config"
     },
     {
-      "name": "g++-13",
+      "name": "g++-14",
       "inherits": "ninja",
-      "displayName": "Ninja with GCC 13",
+      "displayName": "Ninja with GCC 14",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "g++-13"
+        "CMAKE_CXX_COMPILER": "g++-14"
       }
     },
     {
@@ -94,8 +94,8 @@
       "configurePreset": "ninja"
     },
     {
-      "name": "g++-13",
-      "configurePreset": "g++-13"
+      "name": "g++-14",
+      "configurePreset": "g++-14"
     },
     {
       "name": "clang++-17",
@@ -120,8 +120,8 @@
       "configurePreset": "ninja"
     },
     {
-      "name": "g++-13",
-      "configurePreset": "g++-13"
+      "name": "g++-14",
+      "configurePreset": "g++-14"
     },
     {
       "name": "clang++-17",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,11 +68,11 @@
       }
     },
     {
-      "name": "clang++-17",
+      "name": "clang++-18",
       "inherits": "ninja",
       "displayName": "Ninja with Clang 17",
       "cacheVariables": {
-        "CMAKE_CXX_COMPILER": "clang++-17"
+        "CMAKE_CXX_COMPILER": "clang++-18"
       }
     }
   ],
@@ -98,8 +98,8 @@
       "configurePreset": "g++-14"
     },
     {
-      "name": "clang++-17",
-      "configurePreset": "clang++-17"
+      "name": "clang++-18",
+      "configurePreset": "clang++-18"
     }
   ],
   "testPresets": [
@@ -124,8 +124,8 @@
       "configurePreset": "g++-14"
     },
     {
-      "name": "clang++-17",
-      "configurePreset": "clang++-17"
+      "name": "clang++-18",
+      "configurePreset": "clang++-18"
     }
   ]
 }


### PR DESCRIPTION
* Update API token for pushing to TeideStats
* Add more logging to apt install
* Fix choco-install not finding install path
* Bump gcc version to 14
* Use ubuntu-24.04 for build and test jobs
* Bump clang version to 18
