### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         lfs: false
         submodules: recursive
@@ -53,14 +53,14 @@ jobs:
 
     - name: Cache
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4.0.2
       with:
         key: vcpkg-export-${{env.VCPKG_TRIPLET}}-${{hashFiles('vcpkg.json', 'vcpkg-configuration.json', 'external/ports/**', 'cmake/triplets/*.cmake', 'cmake/toolchains/*.cmake')}}
         path: './exports'
 
     - name: Free disk space (Ubuntu)
       if: runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true'
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@v1.3.1
 
     - name: 'Setup NuGet credentials'
       if: steps.cache.outputs.cache-hit != 'true'
@@ -78,7 +78,7 @@ jobs:
 
     - name: Setup vcpkg
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.5
       with:
         vcpkgDirectory: '${{github.workspace}}/external/vcpkg'
         vcpkgJsonGlob: 'vcpkg.json'
@@ -127,7 +127,7 @@ jobs:
 
     - name: Save packages as artifact
       if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: vcpkg-export-${{env.VCPKG_TRIPLET}}
         path: './exports'

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         lfs: true
         submodules: false
@@ -113,7 +113,7 @@ jobs:
 
     - name: Save CMake trace
       if: inputs.profile-cmake
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: CMakeTrace-${{env.job_name}}
         path: ./CMakeTrace.json
@@ -140,7 +140,7 @@ jobs:
 
     - name: Save render test output
       if: failure() && steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: RenderTestOutput-${{env.job_name}}
         path: ${{env.RT_OUTPUT_DIR}}
@@ -158,14 +158,14 @@ jobs:
 
     - name: Save test log
       if: failure() && steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: TestLog-${{env.job_name}}
         path: build/${{matrix.preset}}/Testing/Temporary/LastTest.log
 
     - name: Upload coverage report
       if: matrix.coverage == 'ON'
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4.5.0
       with:
         directory: build/${{matrix.preset}}/coverage/output
         fail_ci_if_error: false
@@ -174,7 +174,7 @@ jobs:
 
     - name: Save coverage report
       if: matrix.coverage == 'ON'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: CoverageReport-${{env.job_name}}
         path: build/${{matrix.preset}}/coverage/output
@@ -191,7 +191,7 @@ jobs:
       ANY_FAILED: "${{needs.unified.outputs.rendertest-failures}}"
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4.1.8
       if: needs.unified.outputs.rendertest-failures
       with:
         path: artifacts

--- a/.github/workflows/Check-Readme.yml
+++ b/.github/workflows/Check-Readme.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         lfs: false
         submodules: recursive
@@ -36,7 +36,7 @@ jobs:
       uses: ./.github/actions/install-dependencies
 
     - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.5
       with:
         vcpkgDirectory: '${{github.workspace}}/external/vcpkg'
         vcpkgJsonGlob: 'vcpkg.json'

--- a/.github/workflows/Run-Benchmarks.yml
+++ b/.github/workflows/Run-Benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         fetch-depth: 0
         submodules: false
@@ -75,7 +75,7 @@ jobs:
         bash .github/scripts/update-comment.sh ${{github.ref_name}} github-actions comment.md
 
     - name: Save output
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: BenchmarkResults
         path: benchmark_results

--- a/.github/workflows/Static-Analysis.yml
+++ b/.github/workflows/Static-Analysis.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         submodules: true
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         submodules: true
@@ -106,13 +106,13 @@ jobs:
 
     - name: Report issues as PR comments
       if: failure() && github.event_name == 'pull_request'
-      uses: reviewdog/action-suggester@v1
+      uses: reviewdog/action-suggester@v1.16.0
       with:
         tool_name: clang-tidy
 
     - name: Save fixes as build artifact
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: clang-tidy-fixes
         path: ${{github.workspace}}/build/${{env.preset}}/clang-tidy-fixes.yaml

--- a/.github/workflows/Update-Actions.yml
+++ b/.github/workflows/Update-Actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.1.7
       with:
         lfs: false
         # [Required] Access token with `workflow` scope.

--- a/.github/workflows/Update-References.yml
+++ b/.github/workflows/Update-References.yml
@@ -26,7 +26,7 @@ jobs:
           --dir artifacts
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.7
       with:
         lfs: true
         submodules: false


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reviewdog/action-suggester](https://github.com/reviewdog/action-suggester)** published a new release **[v1.16.0](https://github.com/reviewdog/action-suggester/releases/tag/v1.16.0)** on 2024-07-07T00:23:40Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.5.0](https://github.com/codecov/codecov-action/releases/tag/v4.5.0)** on 2024-06-18T12:09:49Z
* **[lukka/run-vcpkg](https://github.com/lukka/run-vcpkg)** published a new release **[v11.5](https://github.com/lukka/run-vcpkg/releases/tag/v11.5)** on 2024-02-11T16:20:06Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.4](https://github.com/actions/upload-artifact/releases/tag/v4.3.4)** on 2024-07-05T15:15:04Z
* **[jlumbroso/free-disk-space](https://github.com/jlumbroso/free-disk-space)** published a new release **[v1.3.1](https://github.com/jlumbroso/free-disk-space/releases/tag/v1.3.1)** on 2023-10-27T03:17:07Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.8](https://github.com/actions/download-artifact/releases/tag/v4.1.8)** on 2024-07-05T15:12:41Z
