### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Static-Analysis.yml
+++ b/.github/workflows/Static-Analysis.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Report issues as PR comments
       if: failure() && github.event_name == 'pull_request'
-      uses: reviewdog/action-suggester@v1.16.0
+      uses: reviewdog/action-suggester@v1.17.0
       with:
         tool_name: clang-tidy
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[reviewdog/action-suggester](https://github.com/reviewdog/action-suggester)** published a new release **[v1.17.0](https://github.com/reviewdog/action-suggester/releases/tag/v1.17.0)** on 2024-07-14T12:53:43Z
