### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Checkout
       if: steps.package-config.outputs.changed != 'false'
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         lfs: false
         submodules: recursive

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         lfs: true
         submodules: false

--- a/.github/workflows/Check-Readme.yml
+++ b/.github/workflows/Check-Readme.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         lfs: false
         submodules: recursive

--- a/.github/workflows/Run-Benchmarks.yml
+++ b/.github/workflows/Run-Benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         fetch-depth: 0
         submodules: false

--- a/.github/workflows/Static-Analysis.yml
+++ b/.github/workflows/Static-Analysis.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         submodules: true
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         submodules: true
@@ -106,7 +106,7 @@ jobs:
 
     - name: Report issues as PR comments
       if: failure() && github.event_name == 'pull_request'
-      uses: reviewdog/action-suggester@v1.17.0
+      uses: reviewdog/action-suggester@v1.18.0
       with:
         tool_name: clang-tidy
 

--- a/.github/workflows/Update-Actions.yml
+++ b/.github/workflows/Update-Actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v4.2.0
       with:
         lfs: false
         # [Required] Access token with `workflow` scope.

--- a/.github/workflows/Update-References.yml
+++ b/.github/workflows/Update-References.yml
@@ -26,7 +26,7 @@ jobs:
           --dir artifacts
 
     - name: Checkout
-      uses: actions/checkout@v4.1.7
+      uses: actions/checkout@v4.2.0
       with:
         lfs: true
         submodules: false


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
* **[reviewdog/action-suggester](https://github.com/reviewdog/action-suggester)** published a new release **[v1.18.0](https://github.com/reviewdog/action-suggester/releases/tag/v1.18.0)** on 2024-09-16T03:36:21Z
