### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-Packages.yml
+++ b/.github/workflows/Build-Packages.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Checkout
       if: steps.package-config.outputs.changed != 'false'
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         lfs: false
         submodules: recursive
@@ -75,7 +75,7 @@ jobs:
     - name: Cache
       if: steps.package-config.outputs.changed != 'false'
       id: cache
-      uses: actions/cache@v4.0.2
+      uses: actions/cache@v4.1.2
       with:
         key: ${{ steps.cache-key.outputs.cache-key }}
         path: './exports'
@@ -126,7 +126,7 @@ jobs:
 
     - name: Save packages as artifact
       if: steps.package-config.outputs.changed != 'false' && steps.cache.outputs.cache-hit != 'true'
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: vcpkg-export-${{ steps.cache-key.outputs.cache-key }}
         path: './exports'

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -80,7 +80,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         lfs: true
         submodules: false
@@ -119,7 +119,7 @@ jobs:
 
     - name: Save CMake trace
       if: inputs.profile-cmake
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: CMakeTrace-${{env.job_name}}
         path: ./CMakeTrace.json
@@ -146,7 +146,7 @@ jobs:
 
     - name: Save render test output
       if: failure() && steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: RenderTestOutput-${{env.job_name}}
         path: ${{env.RT_OUTPUT_DIR}}
@@ -164,14 +164,14 @@ jobs:
 
     - name: Save test log
       if: failure() && steps.test.outcome == 'failure'
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: TestLog-${{env.job_name}}
         path: build/${{matrix.preset}}/Testing/Temporary/LastTest.log
 
     - name: Upload coverage report
       if: matrix.coverage == 'ON'
-      uses: codecov/codecov-action@v4.5.0
+      uses: codecov/codecov-action@v4.6.0
       with:
         directory: build/${{matrix.preset}}/coverage/output
         fail_ci_if_error: false
@@ -180,7 +180,7 @@ jobs:
 
     - name: Save coverage report
       if: matrix.coverage == 'ON'
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: CoverageReport-${{env.job_name}}
         path: build/${{matrix.preset}}/coverage/output

--- a/.github/workflows/Check-Readme.yml
+++ b/.github/workflows/Check-Readme.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         lfs: false
         submodules: recursive

--- a/.github/workflows/Run-Benchmarks.yml
+++ b/.github/workflows/Run-Benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         fetch-depth: 0
         submodules: false
@@ -75,7 +75,7 @@ jobs:
         bash .github/scripts/update-comment.sh ${{github.ref_name}} github-actions comment.md
 
     - name: Save output
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: BenchmarkResults
         path: benchmark_results

--- a/.github/workflows/Static-Analysis.yml
+++ b/.github/workflows/Static-Analysis.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         submodules: true
@@ -62,7 +62,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
         submodules: true
@@ -112,7 +112,7 @@ jobs:
 
     - name: Save fixes as build artifact
       if: failure()
-      uses: actions/upload-artifact@v4.4.0
+      uses: actions/upload-artifact@v4.4.3
       with:
         name: clang-tidy-fixes
         path: ${{github.workspace}}/build/${{env.preset}}/clang-tidy-fixes.yaml

--- a/.github/workflows/Update-Actions.yml
+++ b/.github/workflows/Update-Actions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.2.0
+    - uses: actions/checkout@v4.2.2
       with:
         lfs: false
         # [Required] Access token with `workflow` scope.

--- a/.github/workflows/Update-References.yml
+++ b/.github/workflows/Update-References.yml
@@ -26,7 +26,7 @@ jobs:
           --dir artifacts
 
     - name: Checkout
-      uses: actions/checkout@v4.2.0
+      uses: actions/checkout@v4.2.2
       with:
         lfs: true
         submodules: false


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.6.0](https://github.com/codecov/codecov-action/releases/tag/v4.6.0)** on 2024-10-01T14:53:02Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.2](https://github.com/actions/cache/releases/tag/v4.1.2)** on 2024-10-22T13:08:44Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.4.3](https://github.com/actions/upload-artifact/releases/tag/v4.4.3)** on 2024-10-09T17:17:34Z
