### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -171,7 +171,7 @@ jobs:
 
     - name: Upload coverage report
       if: matrix.coverage == 'ON'
-      uses: codecov/codecov-action@v4.6.0
+      uses: codecov/codecov-action@v5.0.7
       with:
         directory: build/${{matrix.preset}}/coverage/output
         fail_ci_if_error: false


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v5.0.7](https://github.com/codecov/codecov-action/releases/tag/v5.0.7)** on 2024-11-21T12:28:45Z
