### PR TITLE
Enable Vulkan validation layers on CI

### DIFF
--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -32,8 +32,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  VULKAN_SDK: ../vulkan_sdk
-
   use_ccache: ${{ inputs.ccache || github.event_name != 'workflow_dispatch' }}
   CCACHE_DEBUGLLEVEL: 1
   CCACHE_DEBUGDIR: ${{ github.workspace }}/ccache_debug

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -220,7 +220,6 @@ jobs:
 
     - name: Test
       id: test
-      env: {GTEST_CATCH_EXCEPTIONS: 0}
       run: ctest --preset ${{matrix.preset}} --build-config ${{matrix.buildtype}} --verbose --output-on-failure --no-tests=error
 
     - name: Save render test output

--- a/.github/workflows/Build-and-Test.yml
+++ b/.github/workflows/Build-and-Test.yml
@@ -112,6 +112,7 @@ jobs:
           ${{ matrix.extra-packages }}
           ${{ env.use_ccache && 'ccache' || '' }}
           ${{ matrix.coverage == 'ON' && runner.os == 'Windows' && 'OpenCppCoverage' || '' }}
+          ${{ runner.os == 'Linux' && 'vulkan-validationlayers' || '' }}
       env:
         GH_TOKEN: ${{ github.token }}
 

--- a/src/Teide/Vulkan.cpp
+++ b/src/Teide/Vulkan.cpp
@@ -369,6 +369,10 @@ vk::UniqueDevice CreateDevice(VulkanLoader& loader, const PhysicalDevice& physic
 
     std::vector<const char*> extensions = physicalDevice.requiredExtensions;
     EnableVulkanExtension(extensions, availableExtensions, "VK_EXT_descriptor_indexing", Required::True);
+    EnableVulkanExtension(extensions, availableExtensions, "VK_KHR_depth_stencil_resolve", Required::True);
+    EnableVulkanExtension(
+        extensions, availableExtensions, "VK_KHR_create_renderpass2",
+        Required::True); // required by "VK_KHR_depth_stencil_resolve"
 
     const vk::StructureChain createInfo = {
         vk::DeviceCreateInfo{

--- a/src/Teide/VulkanDevice.cpp
+++ b/src/Teide/VulkanDevice.cpp
@@ -14,6 +14,7 @@
 #include "VulkanSurface.h"
 #include "VulkanTexture.h"
 
+#include "Teide/Format.h"
 #include "Teide/ShaderData.h"
 #include "Teide/TextureData.h"
 #include "vkex/vkex.hpp"
@@ -21,6 +22,7 @@
 #include <SDL.h>
 #include <SDL_vulkan.h>
 #include <spdlog/spdlog.h>
+#include <vulkan/vulkan_enums.hpp>
 
 #include <algorithm>
 #include <cstdlib>
@@ -777,6 +779,14 @@ Texture VulkanDevice::CreateTexture(const TextureData& data, const char* name, C
     {
         // Need to transfer pixels between mip levels in order to generate mipmaps
         usage |= vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eTransferDst;
+    }
+
+    if (HasDepthOrStencilComponent(data.format))
+    {
+        // According to the Vulkan spec, depth/stencil textures must be created with the depth/stencil attachment bit,
+        // even if they are not intended to be used as attachments.
+        // https://registry.khronos.org/vulkan/specs/latest/html/vkspec.html#VUID-VkImageMemoryBarrier-oldLayout-01210
+        usage |= vk::ImageUsageFlagBits::eDepthStencilAttachment;
     }
 
     VulkanTexture texture;

--- a/src/Teide/VulkanTexture.cpp
+++ b/src/Teide/VulkanTexture.cpp
@@ -3,6 +3,7 @@
 
 #include "Vulkan.h"
 
+#include "Teide/Format.h"
 #include "Teide/TextureData.h"
 
 namespace Teide
@@ -100,7 +101,7 @@ void VulkanTexture::GenerateMipmaps(TextureState& state, vk::CommandBuffer cmdBu
 void VulkanTexture::TransitionToShaderInput(TextureState& state, vk::CommandBuffer cmdBuffer) const
 {
     auto newLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
-    if (state.layout == vk::ImageLayout::eDepthStencilAttachmentOptimal)
+    if (HasDepthOrStencilComponent(properties.format))
     {
         newLayout = vk::ImageLayout::eDepthStencilReadOnlyOptimal;
     }

--- a/tests/RenderTest/src/RenderTest.cpp
+++ b/tests/RenderTest/src/RenderTest.cpp
@@ -300,7 +300,7 @@ Teide::Texture RenderTest::CreateNullShadowmapTexture()
 
     const Teide::TextureData textureData = {
         .size = {1, 1},
-        .format = Teide::Format::Float1,
+        .format = Teide::Format::Depth32,
         .mipLevelCount = 1,
         .samplerState = {
             .magFilter = Teide::Filter::Nearest,

--- a/tests/TeideTest/src/Teide/GpuExecutorTest.cpp
+++ b/tests/TeideTest/src/Teide/GpuExecutorTest.cpp
@@ -117,6 +117,22 @@ TEST_F(GpuExecutorTest, TwoCommandBuffers)
 
     cmdBuffer1->begin(vk::CommandBufferBeginInfo{});
     cmdBuffer1->fillBuffer(buffer.buffer.get(), 0, 8, 0x01010101);
+    cmdBuffer1->pipelineBarrier(
+        vk::PipelineStageFlagBits::eTransfer, // srcStageMask
+        vk::PipelineStageFlagBits::eTransfer, // dstStageMask
+        {},                                   // dependencyFlags
+        {},                                   // memoryBarriers
+        vk::BufferMemoryBarrier{
+            .srcAccessMask = vk::AccessFlagBits::eTransferWrite,
+            .dstAccessMask = vk::AccessFlagBits::eTransferWrite,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .buffer = buffer.buffer.get(),
+            .offset = 0,
+            .size = VK_WHOLE_SIZE,
+        },
+        {} // imageMemoryBarriers
+    );
     cmdBuffer2->begin(vk::CommandBufferBeginInfo{});
     cmdBuffer2->fillBuffer(buffer.buffer.get(), 4, 8, 0x02020202);
 
@@ -145,6 +161,22 @@ TEST_F(GpuExecutorTest, TwoCommandBuffersOutOfOrder)
 
     cmdBuffer1->begin(vk::CommandBufferBeginInfo{});
     cmdBuffer1->fillBuffer(buffer.buffer.get(), 0, 8, 0x01010101);
+    cmdBuffer1->pipelineBarrier(
+        vk::PipelineStageFlagBits::eTransfer, // srcStageMask
+        vk::PipelineStageFlagBits::eTransfer, // dstStageMask
+        {},                                   // dependencyFlags
+        {},                                   // memoryBarriers
+        vk::BufferMemoryBarrier{
+            .srcAccessMask = vk::AccessFlagBits::eTransferWrite,
+            .dstAccessMask = vk::AccessFlagBits::eTransferWrite,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+            .buffer = buffer.buffer.get(),
+            .offset = 0,
+            .size = VK_WHOLE_SIZE,
+        },
+        {} // imageMemoryBarriers
+    );
     cmdBuffer2->begin(vk::CommandBufferBeginInfo{});
     cmdBuffer2->fillBuffer(buffer.buffer.get(), 4, 8, 0x02020202);
 


### PR DESCRIPTION
* Add Vulkan-ValidationLayers component
* Add vulkan-validationlayers (linux only)
* Restore gtest catching exceptions
* Remove VULKAN_SDK environent var from Build-and-Test workflow

Fixes for issues discovered by enabling validation checks:
* Add device extension VK_KHR_create_renderpass2
* Fix incorrect format used for null shadow map in RenderTest
* Use correct image layout for depth/stencil textures
* Initialise depth/stencil textures with the appropriate attachment bit
* Add pipeline barrier to command buffer tests
