### PR TITLE
Integrate stacktraces into TeideTest via cpptrace library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ endif()
 if(TEIDE_BUILD_TESTS)
     find_package(GTest REQUIRED)
     find_package(StackWalker QUIET)
+    find_package(cpptrace CONFIG REQUIRED)
 
     add_subdirectory(tests)
 endif()

--- a/src/Teide/DescriptorPool.cpp
+++ b/src/Teide/DescriptorPool.cpp
@@ -5,6 +5,8 @@
 
 #include "vkex/vkex.hpp"
 
+#include <spdlog/spdlog.h>
+
 namespace Teide
 {
 
@@ -30,6 +32,7 @@ vk::DescriptorSet DescriptorPool::Allocate(const char* name)
     };
 
     auto descriptorSet = m_device.allocateDescriptorSets(allocInfo).front();
+    spdlog::debug("Creating descriptor set '{}'", name);
     SetDebugName(m_device, descriptorSet, name);
 
     m_numAllocatedSets++;

--- a/src/Teide/Vulkan.cpp
+++ b/src/Teide/Vulkan.cpp
@@ -14,9 +14,6 @@
 #include <spdlog/spdlog.h>
 
 #include <memory>
-#if __cpp_lib_stacktrace >= 202012L
-#    include <stacktrace>
-#endif
 
 namespace Teide
 {
@@ -158,13 +155,6 @@ namespace
             TEIDE_ASSERT(severity != MessageSeverity::eError, "{}", pCallbackData->pMessage);
         }
 
-#if __cpp_lib_stacktrace >= 202012L
-        if (severity == MessageSeverity::eError)
-        {
-            std::cout << "Stack trace:\n";
-            std::cout << std::stacktrace::current() << "\n";
-        }
-#endif
         return VK_FALSE;
     }
 

--- a/src/Teide/Vulkan.cpp
+++ b/src/Teide/Vulkan.cpp
@@ -144,15 +144,15 @@ namespace
 
         spdlog::log(logLevel, "{}{}", prefix, pCallbackData->pMessage);
 
-        if constexpr (BreakOnVulkanWarning)
+        if (BreakOnVulkanWarning && severity == MessageSeverity::eWarning)
         {
             // Vulkan warning triggered a debug break
-            TEIDE_ASSERT(severity != MessageSeverity::eWarning, "{}", pCallbackData->pMessage);
+            TEIDE_BREAK("{}", pCallbackData->pMessage);
         }
-        if constexpr (BreakOnVulkanError)
+        if (BreakOnVulkanError && severity == MessageSeverity::eError)
         {
             // Vulkan error triggered a debug break
-            TEIDE_ASSERT(severity != MessageSeverity::eError, "{}", pCallbackData->pMessage);
+            TEIDE_BREAK("{}", pCallbackData->pMessage);
         }
 
         return VK_FALSE;

--- a/src/Teide/Vulkan.cpp
+++ b/src/Teide/Vulkan.cpp
@@ -12,6 +12,7 @@
 
 #include <SDL_vulkan.h>
 #include <spdlog/spdlog.h>
+#include <vulkan/vulkan_enums.hpp>
 
 #include <memory>
 
@@ -21,8 +22,8 @@ namespace Teide
 namespace
 {
     constexpr auto VulkanApiVersion = VK_API_VERSION_1_1;
-    constexpr bool BreakOnVulkanWarning = false;
-    constexpr bool BreakOnVulkanError = true;
+
+    constexpr vk::DebugUtilsMessageSeverityFlagsEXT BreakOnVulkanMessage = vk::DebugUtilsMessageSeverityFlagBitsEXT::eError;
 
     const vk::Optional<const vk::AllocationCallbacks> s_allocator = nullptr;
 
@@ -144,17 +145,10 @@ namespace
 
         spdlog::log(logLevel, "{}{}", prefix, pCallbackData->pMessage);
 
-        if (BreakOnVulkanWarning && severity == MessageSeverity::eWarning)
+        if (severity & BreakOnVulkanMessage)
         {
-            // Vulkan warning triggered a debug break
             TEIDE_BREAK("{}", pCallbackData->pMessage);
         }
-        if (BreakOnVulkanError && severity == MessageSeverity::eError)
-        {
-            // Vulkan error triggered a debug break
-            TEIDE_BREAK("{}", pCallbackData->pMessage);
-        }
-
         return VK_FALSE;
     }
 

--- a/src/Teide/Vulkan.cpp
+++ b/src/Teide/Vulkan.cpp
@@ -13,6 +13,11 @@
 #include <SDL_vulkan.h>
 #include <spdlog/spdlog.h>
 
+#include <memory>
+#if __cpp_lib_stacktrace >= 202012L
+#    include <stacktrace>
+#endif
+
 namespace Teide
 {
 
@@ -152,6 +157,14 @@ namespace
             // Vulkan error triggered a debug break
             TEIDE_ASSERT(severity != MessageSeverity::eError, "{}", pCallbackData->pMessage);
         }
+
+#if __cpp_lib_stacktrace >= 202012L
+        if (severity == MessageSeverity::eError)
+        {
+            std::cout << "Stack trace:\n";
+            std::cout << std::stacktrace::current() << "\n";
+        }
+#endif
         return VK_FALSE;
     }
 

--- a/src/Teide/Vulkan.h
+++ b/src/Teide/Vulkan.h
@@ -9,7 +9,6 @@
 #include "Teide/TextureData.h"
 
 #include <fmt/format.h>
-#include <spdlog/spdlog.h>
 
 #include <chrono>
 #include <span>
@@ -124,7 +123,6 @@ void SetDebugName(vk::Device device [[maybe_unused]], Handle handle [[maybe_unus
     {
         if (VULKAN_HPP_DEFAULT_DISPATCHER.vkSetDebugUtilsObjectNameEXT != nullptr)
         {
-            spdlog::debug("Setting debug name '{}'", debugName);
             device.setDebugUtilsObjectNameEXT({
                 .objectType = handle.objectType,
                 .objectHandle = std::bit_cast<uint64_t>(handle),

--- a/src/Teide/Vulkan.h
+++ b/src/Teide/Vulkan.h
@@ -9,6 +9,7 @@
 #include "Teide/TextureData.h"
 
 #include <fmt/format.h>
+#include <spdlog/spdlog.h>
 
 #include <chrono>
 #include <span>
@@ -123,6 +124,7 @@ void SetDebugName(vk::Device device [[maybe_unused]], Handle handle [[maybe_unus
     {
         if (VULKAN_HPP_DEFAULT_DISPATCHER.vkSetDebugUtilsObjectNameEXT != nullptr)
         {
+            spdlog::debug("Setting debug name '{}'", debugName);
             device.setDebugUtilsObjectNameEXT({
                 .objectType = handle.objectType,
                 .objectHandle = std::bit_cast<uint64_t>(handle),

--- a/tests/TeideTest/CMakeLists.txt
+++ b/tests/TeideTest/CMakeLists.txt
@@ -21,7 +21,11 @@ td_add_test(
     TeideTest
     TARGET Teide
     SOURCES "${sources}"
-    DEPS GTest::gtest GTest::gmock VulkanMemoryAllocator-Hpp::VulkanMemoryAllocator-Hpp ${extra_deps}
+    DEPS GTest::gtest
+         GTest::gmock
+         VulkanMemoryAllocator-Hpp::VulkanMemoryAllocator-Hpp
+         cpptrace::cpptrace
+         ${extra_deps}
     TEST_ARGS ${extra_args})
 
 if(TEIDE_PRECOMPILED_HEADERS)

--- a/tests/TeideTest/src/Main.cpp
+++ b/tests/TeideTest/src/Main.cpp
@@ -41,8 +41,11 @@ std::optional<std::size_t> GetNumConsoleColumns()
     return std::nullopt;
 }
 
-bool AssertDie(std::string_view msg, std::string_view expression, Teide::SourceLocation location)
+bool AssertThrow(std::string_view msg, std::string_view expression, Teide::SourceLocation location)
 {
+    struct AssertException
+    {};
+
     std::cout << location.file_name();
     if (location.line() > 0)
     {
@@ -61,7 +64,7 @@ bool AssertDie(std::string_view msg, std::string_view expression, Teide::SourceL
     {
         std::cout << "Assertion failed: " << expression << ": " << msg << '\n';
     }
-    std::terminate();
+    throw AssertException{};
 }
 
 class LogSuppressor : public testing::EmptyTestEventListener
@@ -214,7 +217,7 @@ int Run(int argc, char** argv)
     }
     else
     {
-        Teide::SetAssertHandler(&AssertDie);
+        Teide::SetAssertHandler(&AssertThrow);
     }
 
     testing::FLAGS_gtest_break_on_failure = Teide::IsDebuggerAttached();

--- a/tests/TeideTest/src/Main.cpp
+++ b/tests/TeideTest/src/Main.cpp
@@ -64,6 +64,12 @@ bool AssertThrow(std::string_view msg, std::string_view expression, Teide::Sourc
     {
         std::cout << "Assertion failed: " << expression << ": " << msg << '\n';
     }
+
+    const auto* curTest = testing::UnitTest::GetInstance()->current_test_info();
+    if (curTest)
+    {
+        std::cout << "Current test: " << curTest->name() << "\n";
+    }
     throw AssertException{};
 }
 

--- a/tests/TeideTest/src/Main.cpp
+++ b/tests/TeideTest/src/Main.cpp
@@ -52,11 +52,12 @@ bool AssertThrow(std::string_view msg, std::string_view expression, Teide::Sourc
     const auto trace = cpptrace::generate_trace();
     for (const auto& frame : trace | std::views::drop(1))
     {
-        if (frame.filename.empty() || frame.filename.ends_with(".so"))
+        if (frame.filename.empty() || frame.filename.ends_with(".so") || frame.filename.contains("/exports/installed")
+            || frame.filename.contains("/vcpkg/buildtrees/"))
         {
             continue;
         }
-        if (frame.symbol.contains("::DebugCallback(") || frame.symbol.starts_with("vk::"))
+        if (frame.symbol.contains("::DebugCallback("))
         {
             continue;
         }

--- a/tests/TeideTest/src/Main.cpp
+++ b/tests/TeideTest/src/Main.cpp
@@ -2,6 +2,8 @@
 #include "Teide/Assert.h"
 #include "Teide/TestUtils.h"
 
+#include <cpptrace/basic.hpp>
+#include <cpptrace/cpptrace.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <spdlog/sinks/ostream_sink.h>
@@ -70,6 +72,8 @@ bool AssertThrow(std::string_view msg, std::string_view expression, Teide::Sourc
     {
         std::cout << "Current test: " << curTest->name() << "\n";
     }
+    std::cout << "Stack trace:\n";
+    cpptrace::generate_trace().print();
     throw AssertException{};
 }
 

--- a/tests/TeideTest/src/Main.cpp
+++ b/tests/TeideTest/src/Main.cpp
@@ -10,6 +10,7 @@
 #include <spdlog/spdlog.h>
 
 #include <exception>
+#include <ranges>
 
 #if __linux__
 #    include <sys/ioctl.h>
@@ -48,6 +49,21 @@ bool AssertThrow(std::string_view msg, std::string_view expression, Teide::Sourc
     struct AssertException
     {};
 
+    const auto trace = cpptrace::generate_trace();
+    for (const auto& frame : trace | std::views::drop(1))
+    {
+        if (frame.filename.empty() || frame.filename.ends_with(".so"))
+        {
+            continue;
+        }
+        if (frame.symbol.contains("::DebugCallback(") || frame.symbol.starts_with("vk::"))
+        {
+            continue;
+        }
+        location = Teide::SourceLocation(frame.line.value_or(0), 0, frame.filename.c_str(), frame.symbol.c_str());
+        break;
+    }
+
     std::cout << location.file_name();
     if (location.line() > 0)
     {
@@ -73,7 +89,6 @@ bool AssertThrow(std::string_view msg, std::string_view expression, Teide::Sourc
         std::cout << "Current test: " << curTest->name() << "\n";
     }
     std::cout << "Stack trace:\n";
-    const auto trace = cpptrace::generate_trace();
     trace.print(std::cout, true);
     throw AssertException{};
 }

--- a/tests/TeideTest/src/Main.cpp
+++ b/tests/TeideTest/src/Main.cpp
@@ -73,7 +73,8 @@ bool AssertThrow(std::string_view msg, std::string_view expression, Teide::Sourc
         std::cout << "Current test: " << curTest->name() << "\n";
     }
     std::cout << "Stack trace:\n";
-    cpptrace::generate_trace().print();
+    const auto trace = cpptrace::generate_trace();
+    trace.print(std::cout, true);
     throw AssertException{};
 }
 

--- a/tests/TeideTest/src/Teide/GpuExecutorTest.cpp
+++ b/tests/TeideTest/src/Teide/GpuExecutorTest.cpp
@@ -48,9 +48,13 @@ protected:
         return {2, GetDevice(), GetQueue(), m_physicalDevice.queueFamilies.transferFamily};
     }
 
-    vk::UniqueCommandBuffer CreateCommandBuffer()
+    vk::UniqueCommandBuffer CreateCommandBuffer(const char* debugName = nullptr)
     {
         auto list = m_device->allocateCommandBuffersUnique({.commandPool = m_commandPool.get(), .commandBufferCount = 1});
+        if (debugName)
+        {
+            Teide::SetDebugName(list.front(), debugName);
+        }
         return std::move(list.front());
     }
 
@@ -111,8 +115,8 @@ TEST_F(GpuExecutorTest, OneCommandBuffer)
 TEST_F(GpuExecutorTest, TwoCommandBuffers)
 {
     auto executor = CreateGpuExecutor();
-    auto cmdBuffer1 = CreateCommandBuffer();
-    auto cmdBuffer2 = CreateCommandBuffer();
+    auto cmdBuffer1 = CreateCommandBuffer("cmdBuffer1");
+    auto cmdBuffer2 = CreateCommandBuffer("cmdBuffer2");
     auto buffer = CreateHostVisibleBuffer(12);
 
     cmdBuffer1->begin(vk::CommandBufferBeginInfo{});

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -59,6 +59,7 @@
       "description": "Build tests",
       "dependencies": [
         "gtest",
+        "cpptrace",
         {
           "name": "stackwalker",
           "platform": "windows & !uwp"


### PR DESCRIPTION
* Dump callstack after a Vulkan validation error
* Give names to command buffers in unit tests
* Change asserts to throw exceptions in TeideTest
* Integrate stacktrace support with cpptrace library
* Add colour to stacktraces
* Use stacktrace to find better source location for assert message
* Break instead of assert on validation errors
* Use flag enum to control when to break on Vulkan message
